### PR TITLE
fix: link to `src` directory guide

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -75,7 +75,7 @@ This command will set up the simplest Plasmo browser extension project for you. 
 | `readme.md`       | Basic documentation                                                                                                                                    |
 | `tsconfig.json`   | TypeScript configuration                                                                                                                               |
 
-> **NOTE:** If you would like to use the `src` directory for your source code (`tsx` and `ts`), please make sure to follow this [guide](/customization#using-src-directory-for-source-code).
+> **NOTE:** If you would like to use the `src` directory for your source code (`tsx` and `ts`), please make sure to follow this [guide](/customization#using-the-src-directory-for-source-code).
 
 ### Building
 


### PR DESCRIPTION
This PR updates a link to the customisation of a `/src` directory for a plasmo app. It currently contains outdated/wrong breadcrumbs.