### PR TITLE
Add another example for the storage API

### DIFF
--- a/src/pages/framework/storage.mdx
+++ b/src/pages/framework/storage.mdx
@@ -39,7 +39,7 @@ const data = await storage.get("key") // value
 ### Storing other data types
 
 ```ts
-const stoarge = new Storage()
+const storage = new Storage()
 
 await storage.set("key", { value: "value" })
 

--- a/src/pages/framework/storage.mdx
+++ b/src/pages/framework/storage.mdx
@@ -36,6 +36,19 @@ await storage.set("key", "value")
 const data = await storage.get("key") // value
 ```
 
+### Storing other data types
+
+```ts
+const stoarge = new Storage()
+
+await storage.set("key", { value: "value" })
+
+const data = await storage.get("key") // { value: "value" }
+
+```
+
+The values stored can be any JSON-ifiable value, including objects and arrays.
+
 ### Customizing the storage area
 
 ```ts


### PR DESCRIPTION
I think it should be mentioned in the documentation that any JSON-ifiable value can be stored without needing to serialize and deserialize it yourself.