### PR TITLE
doc: fix link on src page

### DIFF
--- a/src/pages/framework/customization/src.mdx
+++ b/src/pages/framework/customization/src.mdx
@@ -16,7 +16,7 @@ Creating a Plasmo project with an `src` directory setup is as simple as:
 pnpm create plasmo --with-src
 ```
 
-The command above utilizes Plasmo's [example template feature](/framework/workflows#with-an-example-template).
+The command above utilizes Plasmo's [example template feature](/framework/workflows/new#with-an-example-template).
 
 <Callout>
 


### PR DESCRIPTION
Fixed a link on the [src page](https://docs.plasmo.com/framework/customization/src) to a non-existent page.