### PR TITLE
Fix typo for PlasmoGetShadowHostId

### DIFF
--- a/src/pages/framework/content-scripts-ui/life-cycle.mdx
+++ b/src/pages/framework/content-scripts-ui/life-cycle.mdx
@@ -209,8 +209,8 @@ The function also allows developers to customize the id for each anchor found:
 ```ts
 import type { PlasmoGetShadowHostId } from "plasmo"
 
-export const getShadowHostId: PlasmoGetShadowHostId = ({ anchor }) =>
-  anchor.getAttribute("data-custom-id") + `-pollax-iv`
+export const getShadowHostId: PlasmoGetShadowHostId = ({ element }) =>
+  element.getAttribute("data-custom-id") + `-pollax-iv`
 ```
 
 ### Custom Renderer


### PR DESCRIPTION
Type definition for `PlasmoCSUIAnchor` returns an object with attributes of `element` and `type`. It does not have an `anchor` attribute.

This PR updates docs to match.
