### PR TITLE
Add Edge Case for Overriding Shadow-DOM Styles

### DIFF
--- a/src/pages/framework/content-scripts-ui/styling.mdx
+++ b/src/pages/framework/content-scripts-ui/styling.mdx
@@ -1,3 +1,7 @@
+---
+description: Plasmo CSUI's built-in Root Container allows extension developers to safely style their components.
+---
+
 import { Callout } from "nextra-theme-docs"
 
 # Styling Plasmo CSUI

--- a/src/pages/framework/content-scripts-ui/styling.mdx
+++ b/src/pages/framework/content-scripts-ui/styling.mdx
@@ -124,14 +124,14 @@ See [with-content-scripts-ui/contents/plasmo-overlay.tsx](https://github.com/Pla
 
 ## Styling the Shadow DOM
 
-Use the IDs `#plasmo-mount-container` and `#plasmo-shadow-container` to alter the `Root Container` styles in your CSS:
+Use the IDs `#plasmo-shadow-container` and `plasmo-inline` to alter the `Root Container` styles in your CSS:
 
 ```css filename="style.css"
 #plasmo-shadow-container {
   z-index: 99999;
 }
 
-#plasmo-mount-container {
+#plasmo-inline {
   background: blue;
 }
 ```

--- a/src/pages/framework/content-scripts-ui/styling.mdx
+++ b/src/pages/framework/content-scripts-ui/styling.mdx
@@ -1,6 +1,6 @@
 # Styling Plasmo CSUI
 
-[Plasmo CSUI's built-in `Root Container`](./life-cycle/#root-container) allows extension developers to safely style their components. It ensures that for the most case:
+[Plasmo CSUI's built-in `Root Container`](./life-cycle/#root-container) allows extension developers to safely style their components. It ensures that for the most part:
 
 - The exported style does not leak to the web page
 - The web page's style does not influence the component's styling

--- a/src/pages/framework/content-scripts-ui/styling.mdx
+++ b/src/pages/framework/content-scripts-ui/styling.mdx
@@ -136,6 +136,10 @@ Use the IDs `#plasmo-shadow-container` and `plasmo-inline` to alter the `Root Co
 }
 ```
 
+<Callout emoji="⚠️">
+  See [Root Container Style](#root-container-style) if some styling rules are not being overridden.
+</Callout>
+
 ## Inherit the Web Page's Style
 
 To inherit the web page's style, override the built-in `Root Container` to mount your component directly into the web page's DOM. [Click here for more details](/framework/content-scripts-ui/life-cycle#custom-root-container).

--- a/src/pages/framework/content-scripts-ui/styling.mdx
+++ b/src/pages/framework/content-scripts-ui/styling.mdx
@@ -161,3 +161,11 @@ If the host webpage uses a global `*` specifier to style its page, it can potent
 ```
 
 The above code will cause the root container to have block display. In cases like these, overriding the root container style with an inline style will help keep the container consistent.
+
+There may exist some CSS styling declarations that cannot be overridden to alter the the `Root Container` styles. In those cases, the `!important` flag can be used as a workaround.
+
+```css filename="style.css"
+#plasmo-shadow-container {
+  z-index: 2147483646 !important;
+}
+```

--- a/src/pages/framework/content-scripts-ui/styling.mdx
+++ b/src/pages/framework/content-scripts-ui/styling.mdx
@@ -6,12 +6,12 @@ import { Callout } from "nextra-theme-docs"
 
 # Styling Plasmo CSUI
 
-[Plasmo CSUI's built-in `Root Container`](./life-cycle/#root-container) allows extension developers to safely style their components. It ensures that for the most part:
+[Plasmo CSUI's built-in `Root Container`](/framework/content-scripts-ui/life-cycle/#root-container) allows extension developers to safely style their components. It ensures that for the most part:
 
 - The exported style does not leak to the web page
 - The web page's style does not influence the component's styling
 
-See [edge cases](#edge-cases) for when it does not work.
+See [caveats](#caveats) for when it does not work.
 
 ## Raw CSS Text
 
@@ -143,14 +143,15 @@ Use the IDs `#plasmo-shadow-container` and `plasmo-inline` to alter the `Root Co
 ```
 
 <Callout emoji="⚠️">
-  See [Root Container Style](#root-container-style) if some styling rules are not being overridden.
+  See [Caveats: Root Container Style](#root-container-style) if some styling
+  rules are not being overridden.
 </Callout>
 
 ## Inherit the Web Page's Style
 
 To inherit the web page's style, override the built-in `Root Container` to mount your component directly into the web page's DOM. [Click here for more details](/framework/content-scripts-ui/life-cycle#custom-root-container).
 
-## Edge cases
+## Caveats
 
 There are many situations that the framework's generic style encapsulation cannot handle (yet). Here are some common gotchas:
 
@@ -158,7 +159,11 @@ There are many situations that the framework's generic style encapsulation canno
 
 CSS Variables are shared across every frame within the same browser tab. This means that if the webpage declares some CSS variables at the `:root` context, it will be prioritized over yours.
 
-To mitigate CSS variable sharing between CSUI and the host page, declare a unique prefix namespace for your CSS variables, or hoist your CSS variable under a `:host` scope, or mount your component inside an iframe.
+To mitigate CSS variable sharing between CSUI and the web page, you can either:
+
+- Declare a unique prefix namespace for your CSS variables
+- Hoist your CSS variable under a `:host` scope
+- Mount your component inside an iframe, with its own head and body
 
 ### Root Container Style
 

--- a/src/pages/framework/content-scripts-ui/styling.mdx
+++ b/src/pages/framework/content-scripts-ui/styling.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra-theme-docs"
+
 # Styling Plasmo CSUI
 
 [Plasmo CSUI's built-in `Root Container`](./life-cycle/#root-container) allows extension developers to safely style their components. It ensures that for the most part:


### PR DESCRIPTION
I've made updates to the docs related to the following issue that I reported.

https://github.com/PlasmoHQ/plasmo/issues/416