### PR TITLE
Migrate to PlasmoCSConfig

### DIFF
--- a/src/pages/framework/content-scripts-ui/styling.mdx
+++ b/src/pages/framework/content-scripts-ui/styling.mdx
@@ -72,7 +72,7 @@ To utilize CSS modules, import the stylesheet twice:
 
 ```tsx filename="content.tsx"
 import styleText from "data-text:./style.module.pcss"
-import type { PlasmoContentScript } from "plasmo"
+import type { PlasmoCSConfig } from "plasmo"
 
 import * as style from "./style.module.pcss"
 
@@ -110,7 +110,7 @@ To use a custom font in your CSUI, you must import the font inside a CSS file an
 3. Declare the file in the `css` property of the content script config:
 
 ```tsx filename="content.tsx"
-export const config: PlasmoContentScript = {
+export const config: PlasmoCSConfig = {
   matches: ["https://www.plasmo.com/*"],
   css: ["font.css"]
 }

--- a/src/pages/framework/content-scripts.mdx
+++ b/src/pages/framework/content-scripts.mdx
@@ -50,15 +50,15 @@ See [with-many-content-scripts](https://github.com/PlasmoHQ/examples/tree/main/w
 Sometimes, you'll want to run a content script on certain pages. You can provide a custom content script configuration by exporting a config object from your content script:
 
 ```ts filename="content.ts"
-import type { PlasmoContentScript } from "plasmo"
+import type { PlasmoCSConfig } from "plasmo"
 
-export const config: PlasmoContentScript = {
+export const config: PlasmoCSConfig = {
   matches: ["<all_urls>"],
   all_frames: true
 }
 ```
 
-Working with this configuration object is a breeze thanks to the exported `PlasmoContentScript` type 🥳.
+Working with this configuration object is a breeze thanks to the exported `PlasmoCSConfig` type 🥳.
 
 To learn more about the config and each property, [check out Chrome's official documentation](https://developer.chrome.com/docs/extensions/mv3/content_scripts/#static-declarative).
 

--- a/src/pages/framework/env.mdx
+++ b/src/pages/framework/env.mdx
@@ -113,7 +113,7 @@ import "https://www.plasmo.com/js?id=$PLASMO_PUBLIC_ITERO"
 You can also use environment variables in the [content script config exports](/framework/content-scripts#customizing-content-script-config):
 
 ```ts
-export const config: PlasmoContentScript = {
+export const config: PlasmoCSConfig = {
   matches: ["$PLASMO_PUBLIC_SITE_URL/"]
 }
 ```

--- a/src/pages/framework/messaging.mdx
+++ b/src/pages/framework/messaging.mdx
@@ -83,11 +83,11 @@ Use the Relay Flow to communicate between a target webpage and the background se
 Create a relay inside a content script. The `relay` function takes a message name and an optional handler function. A content script can have multiple relays. Given the `ping` message handler from the previous example, and the website `www.plasmo.com`:
 
 ```ts filename="contents/plasmo.ts"
-import type { PlasmoContentScript } from "plasmo"
+import type { PlasmoCSConfig } from "plasmo"
 
 import { relay } from "@plasmohq/messaging"
 
-export const config: PlasmoContentScript = {
+export const config: PlasmoCSConfig = {
   matches: ["http://www.plasmo.com/*"] // Only relay messages from this domain
 }
 

--- a/src/pages/quickstarts/migrate-to-plasmo.mdx
+++ b/src/pages/quickstarts/migrate-to-plasmo.mdx
@@ -167,9 +167,9 @@ With Plasmo, your can specify your content script and its respective config in a
 Here's what the `content.ts` file would look like:
 
 ```ts filename="content.ts"
-import type { PlasmoContentScript } from "plasmo"
+import type { PlasmoCSConfig } from "plasmo"
 
-export const config: PlasmoContentScript = {
+export const config: PlasmoCSConfig = {
   matches: ["https://*/*", "http://*/*"],
   all_frames: true,
   css: ["~content.css"]


### PR DESCRIPTION
I noticed that `PlasmoContentScript` was deprecated and renamed to `PlasmoCSConfig`. This replaces each instance in the docs to match.