### PR TITLE
Fix src path flag name in the example

### DIFF
--- a/src/pages/framework/customization/internal-path.mdx
+++ b/src/pages/framework/customization/internal-path.mdx
@@ -31,7 +31,7 @@ The default source path is `./src`. To change this behavior, either:
 - Specify the `--src-path` flag:
 
 ```sh
-plasmo build --source-path=src/extension
+plasmo build --src-path=src/extension
 ```
 
 - Or use the `PLASMO_SRC_PATH` top-level environment variable:


### PR DESCRIPTION
The correct flag is `--src-path`. The docs were updated but the example code was not. This simply updates the example code to use `--src-path`.