### PR TITLE
Add message to warn against local CLI tool usage

### DIFF
--- a/src/pages/framework/index.mdx
+++ b/src/pages/framework/index.mdx
@@ -73,6 +73,12 @@ This command will set up the simplest Plasmo browser extension project for you. 
 [guide](/framework/customization/src).
 
 </Callout>
+<Callout emoji="📢">
+
+**NOTE:** If you have a local copy of the Plasmo source code, make sure to not link the `create-plasmo` CLI, as it is not intended to be run locally.
+If you have already linked it, please run `pnpm -g unlink create-plasmo` to unlink it.
+
+</Callout>
 
 ### Development Server
 


### PR DESCRIPTION
Warns against using the local copy of the `create-plasmo` CLI tool as it's not intended for local use, and will cause an error when generating a new plasmo project