### PR TITLE
doc: fix link for an example

### DIFF
--- a/src/pages/framework/content-scripts-ui/life-cycle.mdx
+++ b/src/pages/framework/content-scripts-ui/life-cycle.mdx
@@ -111,7 +111,7 @@ export const watchOverlayAnchor: PlasmoWatchOverlayAnchor = (
 }
 ```
 
-Check [with-content-scripts-ui/contents/plasmo-mount.tsx](https://github.com/PlasmoHQ/examples/blob/main/with-content-scripts-ui/contents/plasmo-mount.tsx) for an example.
+Check [with-content-scripts-ui/contents/plasmo-overlay-watch.tsx](https://github.com/PlasmoHQ/examples/blob/main/with-content-scripts-ui/contents/plasmo-overlay-watch.tsx) for an example.
 
 ### Inline
 


### PR DESCRIPTION
Fixed a link on the [Life Cycle page's update position example](https://docs.plasmo.com/framework/content-scripts-ui/life-cycle#update-position) to a non-existent page.