### PR TITLE
fix code typo in Quickstarts > Migrate to Plasmo

### DIFF
--- a/src/pages/quickstarts/migrate-to-plasmo.mdx
+++ b/src/pages/quickstarts/migrate-to-plasmo.mdx
@@ -74,7 +74,7 @@ import { createRoot } from "react"
 import Popup from "./core/popup"
 
 const root = document.getElementById("root")
-createRoot(root).render(<PopupApp />)
+createRoot(root).render(<Popup />)
 ```
 
 If you wanted to add TypeScript, LESS, or SCSS, you would need to use Webpack, Parcel, or ESBuild, with extra plugins and loader setups.


### PR DESCRIPTION
React component is imported as `Popup` but rendered as `<PopupApp/>`. Made simple fix to align with import name -> `<Popup/>`