### PR TITLE
Update `tsconfig.json` in `customization/src.mdx`

### DIFF
--- a/src/pages/framework/customization/src.mdx
+++ b/src/pages/framework/customization/src.mdx
@@ -38,7 +38,7 @@ The new configuration looks like this:
 {
   "extends": "plasmo/templates/tsconfig.base",
   "exclude": ["node_modules"],
-  "include": [".plasmo/**/*", "./**/*.ts", "./**/*.tsx"],
+  "include": [".plasmo/index.d.ts", "./**/*.ts", "./**/*.tsx"],
   "compilerOptions": {
     "paths": {
       "~*": ["./src/*"]


### PR DESCRIPTION
Removes `.plasmo/**/*` from `includes` in `tsconfig.json` as mentioned in the comment:  https://github.com/PlasmoHQ/plasmo/issues/274#issuecomment-1293202261.

Adds `.plasmo/index.d.ts` because it is included in default.
https://github.com/PlasmoHQ/plasmo/blob/44b723f3013d0e5e43619436688a0be4dd747858/packages/init/templates/tsconfig.json#L4

I checked other files and found that the alias page had several `tsconfig.json` but didn't include both `.plasmo/**/*` and `.plasmo/index.d.ts`. I was unsure if it was a problem, so I ignored it.

https://github.com/PlasmoHQ/docs/blob/main/src/pages/framework/customization/alias.mdx