### PR TITLE
fix(typo): In tsconfig, paths key requires wildcard '/*'

### DIFF
--- a/src/pages/framework/customization/alias.mdx
+++ b/src/pages/framework/customization/alias.mdx
@@ -21,7 +21,7 @@ To alias local imports, use the `paths` mapping in `tsconfig.json`:
   "compilerOptions": {
     "paths": {
       "~*": ["./src/*"],
-      "@Components": ["./src/components/*"]
+      "@Components/*": ["./src/components/*"]
     },
     "baseUrl": "."
   }


### PR DESCRIPTION
` "@Components": ["./src/components/*"]` would cause ` Error parsing JSON`, adding '/*' fixes it.
https://www.typescriptlang.org/tsconfig#paths
![Snipaste_2023-08-14_19-53-44](https://github.com/PlasmoHQ/docs/assets/104723527/af8392e5-362f-4392-8bc9-326518cd968e)
