### PR TITLE
Add new documentation about specifying dev server hostname and port

### DIFF
--- a/src/pages/framework/workflows/dev.mdx
+++ b/src/pages/framework/workflows/dev.mdx
@@ -53,3 +53,17 @@ plasmo dev --no-source-maps
 ```
 
 This is useful when you have dependencies that don't play well with source maps.
+
+## With a specific hostname and port
+
+The development server will, by default, bind to `localhost` and port `1012`. You can change these with `--serve-host` and `--serve-port`:
+
+```sh
+plasmo dev --serve-host=localhost --serve-port-1012
+```
+
+Similarly, the hot module reload websocket will, by default, bind to `localhost` and port `1815`, with the build reporter binding to the HMR socket + 1 (1816 by default). You can change these with `--hmr-host` and `--hmr-port`:
+
+```sh
+plasmo dev --hmr-host=localhost --hmr-port=1815
+```


### PR DESCRIPTION
Adds a new section to the docs following https://github.com/PlasmoHQ/plasmo/pull/745 that details how to change the hostname and port for the dev server and HMR.