### PR TITLE
doc: add firefox note for storage api

### DIFF
--- a/src/pages/framework/storage.mdx
+++ b/src/pages/framework/storage.mdx
@@ -218,3 +218,23 @@ return <>
 </>
 
 ```
+
+### Usage with Firefox
+
+To use the storage API on Firefox during development you need to add an addon ID to your manifest, otherwise, you will get this error:
+
+> Error: The storage API will not work with a temporary addon ID. Please add an explicit addon ID to your manifest. For more information see https://mzl.la/3lPk1aE.
+
+To add an addon ID to your manifest, add this to your package.json:
+
+```JSON
+"manifest": {
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "your-id@example.com"
+    }
+  }
+}
+```
+
+During development, you may use any ID. If you have published your extension, you can use the ID assigned by Mozilla Addons.


### PR DESCRIPTION
This is a copy+paste from the PlasmoHQ/storage README.md. The development note should be in the main documentation as a user will likely encounter the bug well before they get the addon published or start diving into the individual packages.