### PR TITLE
doc: Service worker in dev mode will always remain active

### DIFF
--- a/src/pages/framework/background-service-worker.mdx
+++ b/src/pages/framework/background-service-worker.mdx
@@ -37,6 +37,10 @@ See [with-background](https://github.com/PlasmoHQ/examples/tree/main/with-backgr
 
 ## Persisting state
 
+<Callout emoji="⚠️">
+  Service workers in Plasmo `dev` mode will always remain `active`.
+</Callout>
+
 The worker becomes idle after a few seconds of inactivity, and the browser will kill its process entirely after 5 minutes. This means all state (variables, etc.) is lost unless you use a storage engine.
 
 The simplest way to persist your background service worker's state is to use the [storage API](/framework/storage).


### PR DESCRIPTION
Service worker in `dev` mode will always remain `active`, and when I load the `prod` mode extension in chrome, it quickly becomes `inactive`.
It took me some time to realize that this was not a bug written by me.🤣
![Snipaste_2023-10-03_20-17-16](https://github.com/PlasmoHQ/docs/assets/104723527/16d22203-fbfa-4cc5-b138-c3940d50e3c8)
