### PR TITLE
docs: add sidepanel to extension pages docs

### DIFF
--- a/src/pages/framework/ext-pages.mdx
+++ b/src/pages/framework/ext-pages.mdx
@@ -6,7 +6,7 @@ import { Callout } from "nextra-theme-docs"
 
 # Browser Extension Pages
 
-Extension pages are built-in pages recognized by the browser. They include the extension's popup, options, and newtab pages.
+Extension pages are built-in pages recognized by the browser. They include the extension's popup, options, sidepanel and newtab pages.
 
 <Callout emoji="👀">
   Heads up! Make sure to refresh your extension manually when creating a new

--- a/src/pages/framework/ext-pages.mdx
+++ b/src/pages/framework/ext-pages.mdx
@@ -38,6 +38,14 @@ Create a `newtab.tsx` file or a `newtab/index.tsx` file, and Plasmo will take ca
 
 See [with-newtab](https://github.com/PlasmoHQ/examples/tree/main/with-newtab)
 
+## Adding a Side Panel
+
+The Side Panel allows extensions to display their own UI in the side panel, enabling persistent experiences that complement the user's browsing journey.
+
+Create a `sidepanel.tsx` file or a `sidepanel/index.tsx` file, and Plasmo will take care of the rest to render the UI in the Side Panel. 
+
+See [with-sidepanel](https://github.com/PlasmoHQ/examples/tree/main/with-sidepanel)
+
 ## Adding a Dev Tools Page
 
 The Dev Tools page is a dedicated page that opens when a user opens the Dev Tools for the extension.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
-->

## Details

Sidepanel landed in [#651](https://github.com/PlasmoHQ/plasmo/pull/651), but the corresponding docs are missing. This PR adds basic information about Sidepanel in the extension pages docs with a link to the example usage. 

> P.S: I thought of adding an entire page dedicated to Side Panel, but I'm unaware of the structure that needs to be followed. If any contributor can point me to the right direction, I shall update this PR with dedicated Sidepanel docs as well.  

fixes: https://github.com/PlasmoHQ/plasmo/issues/783

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I agree to license this contribution under the MIT LICENSE
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d