### PR TITLE
docs: add notification when using the src directory with assets

### DIFF
--- a/src/pages/framework/customization/src.mdx
+++ b/src/pages/framework/customization/src.mdx
@@ -20,6 +20,8 @@ The command above utilizes Plasmo's [example template feature](/framework/workfl
 
 <Callout>
 
+Please ensure that the `assets` directory is in the `project` directory NOT the `src` directory.
+
 Please ensure that **ALL source files** including Plasmo's entry files such as `popup.tsx`, `options.tsx`, `background.ts`, `contents/*` etc. are in the `src` directory. Otherwise, Plasmo **WILL NOT** know where to find the entry files, resulting in an empty extension!
 
 This customization only resolves `~` to `/src` for source code


### PR DESCRIPTION
Some users may accidentally move the assets directory to the src directory, which will cause `pnpm run dev` to fail.

https://github.com/PlasmoHQ/plasmo/issues/825