### PR TITLE
add note about storage api being used in main world

### DIFF
--- a/src/pages/framework/storage.mdx
+++ b/src/pages/framework/storage.mdx
@@ -97,6 +97,12 @@ await storage.set("make", "PlasmoHQ")
 
 This can be used as a layer to communicate messages across your extension. We demonstrate this in the [with-redux](https://github.com/PlasmoHQ/examples/tree/main/with-redux) example.
 
+<Callout emoji="📢">
+
+**NOTE:** The Storage API is not available in a Content Script when it is executed in the 'MAIN' world, as it loses its access to the Chrome Extensions APIs.
+
+</Callout>
+
 ## Secure Storage
 
 The SecureStorage API extends Storage with data encryption and decryption for at-rest cold storage of sensitive keys. It utilizes the [Web Crypto `SubtleCrypto` API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto) which only works in secure contexts (HTTPS).

--- a/src/pages/framework/storage.mdx
+++ b/src/pages/framework/storage.mdx
@@ -3,6 +3,7 @@ description: A library that makes it easy to store data in your browser extensio
 ---
 
 import { ShieldBanners } from "~components/shield-banners"
+import { Callout } from "nextra-theme-docs"
 
 # Storage API
 


### PR DESCRIPTION
I've spent a significant time trying to find out, why my storage-watcher was not responding to changes made in my Popup. The build folder needs to be be deleted, in order to apply changes made in the PlasmoCSConfig; this made debugging not easier. A note, which states that the Storage API is not available in the main-world, would have saved me a ton of time.

I assume other users have the same point of view, as you can see in the following issues:

- #57 (particulary this one)
- #60
- #48 