### PR TITLE
fix code typo in Quickstarts > Quickstart with Firebase Auth

### DIFF
--- a/src/pages/quickstarts/with-firebase-authentication.mdx
+++ b/src/pages/quickstarts/with-firebase-authentication.mdx
@@ -631,12 +631,5 @@ const logout = async (e: any) => {
     } catch (error: any) {
       console.log(error.message)
     }
-  }const logout = async (e: any) => {
-    e.preventDefault()
-    try {
-      await onLogout()
-    } catch (error: any) {
-      console.log(error.message)
-    }
   }
 ```


### PR DESCRIPTION
I made a simple fix to remove one of the duplicated definitions of the logout function.

<img width="1510" alt="スクリーンショット 2024-03-23 1 41 42" src="https://github.com/PlasmoHQ/docs/assets/67625825/46aed22e-dc6c-4b88-a08b-6cd671f8a8b2">
