### PR TITLE
[DOCUMENTATION] Updated Misleading "Relay Flow" Documentation

### DIFF
--- a/src/pages/framework/messaging.mdx
+++ b/src/pages/framework/messaging.mdx
@@ -175,12 +175,12 @@ const resp = await sendToBackgroundViaRelay({
 console.log(resp)
 ```
 
-To relay messages from contexts where `chrome.runtime` is unavailable, you can use the `relayMessage` function:
+To relay messages from contexts where `chrome.runtime` is unavailable, you can use the `sendViaRelay` function:
 
 ```tsx filename="sandbox.tsx"
-import { relayMessage } from "@plasmohq/messaging"
+import { sendViaRelay } from "@plasmohq/messaging/relay"
 
-relayMessage({
+sendViaRelay({
     name: "ping"
 })
 ```

--- a/src/pages/framework/messaging.mdx
+++ b/src/pages/framework/messaging.mdx
@@ -175,23 +175,14 @@ const resp = await sendToBackgroundViaRelay({
 console.log(resp)
 ```
 
-To relay messages from contexts where `chrome.runtime` is unavailable, you can use the `relay` function:
+To relay messages from contexts where `chrome.runtime` is unavailable, you can use the `relayMessage` function:
 
 ```tsx filename="sandbox.tsx"
-import { relayMessage } from "@plasmohq/messaging/relay"
+import { relayMessage } from "@plasmohq/messaging"
 
-relayMessage(
-  {
+relayMessage({
     name: "ping"
-  },
-  async (req) => {
-    console.log("some message was relayed:", req)
-
-    return {
-      message: "Hello from sandbox"
-    }
-  }
-)
+})
 ```
 
 ## Ports


### PR DESCRIPTION
The documentation for "relay flow" was previously misleading as there exists no `relayMessage` function in`@plasmohq/messaging/relay`