### PR TITLE
fix: listener removal in port docs

### DIFF
--- a/src/pages/framework/messaging.mdx
+++ b/src/pages/framework/messaging.mdx
@@ -240,18 +240,18 @@ In your extension page, get the port using the `getPort` utility under the `@pla
 
   let output = ""
 
+  const messageListener = (msg) => {
+    output = msg
+  }
+
   const mailPort = getPort("mail")
 
   onMount(() => {
-    mailPort.onMessage.addListener((msg) => {
-      output = msg
-    })
+    mailPort.onMessage.addListener(messageListener)
   })
 
   onDestroy(() => {
-    mailPort.onMessage.removeListener((msg) => {
-      output = msg
-    })
+    mailPort.onMessage.removeListener(messageListener)
   })
 
   function handleSubmit() {


### PR DESCRIPTION
In this PR, I fixed an issue where `addListener` and `removeListener` were not using the same reference for the listener function. 
This caused the removal of the listener to fail, as `removeListener` requires the exact function reference that was initially passed to `addListener`. 
To resolve this, I stored the listener function in a variable and reused it for both adding and removing the listener.
