### PR TITLE
Integrate Mellowtel into Plasmos Docs

### DIFF
--- a/src/pages/quickstarts.mdx
+++ b/src/pages/quickstarts.mdx
@@ -15,4 +15,5 @@ We have many examples showcasing how to use Plasmo with:
 - [Firebase Authentication](/quickstarts/with-firebase-authentication)
 - [Supabase Authentication](/quickstarts/with-supabase)
 - [Google Analytics](/quickstarts/with-google-analytics)
+- [Monetization](/quickstarts/with-mellowtel)
 - And many more: [visit the examples repository!](https://github.com/PlasmoHQ/examples)

--- a/src/pages/quickstarts.mdx
+++ b/src/pages/quickstarts.mdx
@@ -15,5 +15,5 @@ We have many examples showcasing how to use Plasmo with:
 - [Firebase Authentication](/quickstarts/with-firebase-authentication)
 - [Supabase Authentication](/quickstarts/with-supabase)
 - [Google Analytics](/quickstarts/with-google-analytics)
-- [Monetization](/quickstarts/with-mellowtel)
+- [Mellowtel Integration](/quickstarts/with-mellowtel)
 - And many more: [visit the examples repository!](https://github.com/PlasmoHQ/examples)

--- a/src/pages/quickstarts/_meta.json
+++ b/src/pages/quickstarts/_meta.json
@@ -7,5 +7,6 @@
   "with-supabase": "Quickstart: Supabase",
   "with-firebase-authentication": "Quickstart: Firebase Auth",
   "with-google-analytics": "Quickstart: Google Analytics",
-  "with-chrome-storage": "Quickstart: Chrome Storage"
+  "with-chrome-storage": "Quickstart: Chrome Storage",
+  "with-mellowtel": "Quickstart: Mellowtel"
 }

--- a/src/pages/quickstarts/with-mellowtel.mdx
+++ b/src/pages/quickstarts/with-mellowtel.mdx
@@ -1,0 +1,145 @@
+---
+description: A quick guide on how to integrate Mellowtel for monetization in your Plasmo browser extension.
+---
+
+import { Callout } from "nextra-theme-docs"
+
+# Quickstart with Mellowtel
+
+Integrating [Mellowtel](https://mellowtel.com) with Plasmo allows you to monetize your browser extension by sharing users' unused internet bandwidth. This guide provides two paths: starting a new project with Mellowtel or adding Mellowtel to an existing project.
+
+<Callout emoji="💰">Easy monetization for your Plasmo Extension!</Callout>
+
+## Starting a New Project with Mellowtel
+
+To create a new Plasmo project with Mellowtel integration, use the following command:
+
+```bash
+pnpm create plasmo --with-mellowtel
+```
+
+This command sets up a new project with all necessary configurations and dependencies for Mellowtel integration.
+
+## Manual Installation for Existing Projects
+
+If you have an existing Plasmo project and want to add Mellowtel, follow these steps:
+
+### Step 1: Add Dependencies
+
+Add Mellowtel to your project:
+
+```bash
+pnpm add mellowtel
+```
+
+### Step 2: Update package.json
+
+Ensure your `package.json` includes the necessary permissions and host permissions:
+
+```json filename="package.json"
+{
+  "manifest": {
+    "permissions": [
+      "storage",
+      "declarativeNetRequest"
+    ],
+    "host_permissions": ["<all_urls>"]
+  }
+}
+```
+
+### Step 3: Configure Environment Variables
+
+Create or update your `.env` file with the Mellowtel API key:
+
+```plaintext filename=".env"
+PLASMO_PUBLIC_MELLOWTEL=your_mellowtel_api_key_here
+```
+
+<Callout emoji="⚠️">
+  Replace `your_mellowtel_api_key_here` with your actual Mellowtel API key.
+</Callout>
+
+### Step 4: Implement Mellowtel in Your Extension
+
+#### In Background Script
+
+```tsx filename="background.ts"
+import Mellowtel from "mellowtel"
+
+let mellowtel
+;(async () => {
+  mellowtel = new Mellowtel(process.env.PLASMO_PUBLIC_MELLOWTEL)
+  await mellowtel.initBackground()
+})()
+
+chrome.runtime.onInstalled.addListener(async function (details) {
+  console.log("Extension Installed or Updated", details)
+  await mellowtel.generateAndOpenOptInLink()
+})
+```
+
+#### In Content Script
+
+```tsx filename="content.ts"
+import Mellowtel from "mellowtel"
+import type { PlasmoCSConfig } from "plasmo"
+
+let mellowtel
+
+export const config: PlasmoCSConfig = {
+  matches: ["<all_urls>"],
+  all_frames: true,
+  run_at: "document_start"
+}
+
+const start = async () => {
+  mellowtel = new Mellowtel(process.env.PLASMO_PUBLIC_MELLOWTEL)
+  const resp = await mellowtel.initContentScript()
+}
+
+start()
+```
+
+#### In Popup
+
+```tsx filename="popup.tsx"
+import Mellowtel from "mellowtel"
+
+const Popup: React.FC = () => {
+  const handleMellowtelSettings = async () => {
+    const mellowtel = new Mellowtel(process.env.PLASMO_PUBLIC_MELLOWTEL)
+    const link = await mellowtel.generateSettingsLink()
+    chrome.tabs.create({ url: link })
+  }
+
+  return (
+    <div>
+      <button onClick={handleMellowtelSettings}>
+        Change Mellowtel Settings
+      </button>
+    </div>
+  )
+}
+
+export default Popup
+```
+
+## Development and Building
+
+Use these scripts for development and building:
+
+- `pnpm dev`: Start the development server
+- `pnpm build`: Build the extension for production
+- `pnpm package`: Package the built extension
+
+<Callout emoji="🚀">
+  Always test your extension thoroughly in both development and production
+  builds to ensure Mellowtel is functioning correctly.
+</Callout>
+
+<Callout emoji="📚">
+  For more in-depth information on Mellowtel's functionality, API, and best
+  practices, visit the [Mellowtel
+  documentation](https://docs.mellowtel.com/get-started/welcome).
+</Callout>


### PR DESCRIPTION
Dear Plasmo Community,

Given the recent discussion regarding the Mellowtel docs on Plasmo voiced by some users on the discord server and X, we want to bring up this topic to the attention of the broader community for an open discussion. As a disclaimer: I work for Mellowtel.

**Summary of what happened so far:**
A few weeks ago I created a PR to add an example to Plasmo. I talked to Louis (founder of Plasmo) beforehand and he liked the idea, so he merged it. After further feedback, we have reverted that PR and are starting this discussion here.

**Summary of Mellowtel:**
Mellowtel is an open source library that developers can decide if they want to import in their plugin or not. If they import it, the library lets users of a browser plugin decide if they want to support the developer of that plugin by sharing their unused internet bandwidth. This is used by companies to access the web in a credentialless environment (e.g to retrieve publicly available data) and they pay for it. A portion of the revenue is shared with developers of the plugin. All users are opted out by default and they have to explicitly opt-in if they want to support the plugin and the developer. Users can change their settings at any time. The library does not collect or sell users data, unlike ads network, since it relies on using a small portion of bandwidth. It does not affect browsing experience or battery life since it requires just enough bandwidth to open an additional incognito tab and it’s optimized (e.g. rate limiting). Anyone can look at the [source code](https://github.com/mellowtel-inc/mellowtel-js) on Github and see how it operates.

While we have now over 100 plugins (from a few hundred users to tens of thousands) using the library and tens of developers using and recommending the library, there has been some valid concerns raised by some users in the plasmo community. Feel free to add further points.

**Quick summary of the feedback:**

- The title of the integration with the Plasma docs is misleading. The title was “Quickstart with Monetization”. The criticism was on the fact that the title made it seem we are the only possible solution to monetize which is obviously not true. Now the title is in line with the others present on the plasma docs (e.g. Quickstart: Supabase, Quickstart: Firebase Auth): Quickstart: Mellowtel
- The documentation of Mellowtel is not explaining the concept well, which looks shady
- The addition of Mellowtel to the docs was not a public discussion and by being in the Plasmo docs it gives the impression of an endorsement

Obviously, our goal is that these docs are beneficial to Plasmo and its community. While some of the feedback provided was based on misinformation, there also has been a lot of good feedback that we will be adding to our own docs.  I hope to kick off a discussion about whether to have an example of Mellowtel in the docs and to get opinions from further community members. 


So please vote one of the following using the Emojis:

- 👍 Readd the Mellowtel docs to Plasmo, with the title "Quickstart with Mellowtel"
- ❤️ Create a quickstart called "Quickstart with Monetization", where we add different ways for browser plugin developers to earn: Mellowtel and other suggestions from the community on how they were able to earn thanks to their plugin
- 👀 Make changes to Mellowtel or Mellowtels docs before applying again, based on the feedback of plasmos community
- 👎 Don't Add


Would love to hear the community's opinion  and we are happy to clarify further, if needed. 

EDIT:
This vote is only open for previous Plasmo contributors, all other votes will be ignored
