### PR TITLE
chore: update documentation quickstart with tailwind

### DIFF
--- a/src/pages/quickstarts/with-tailwindcss.mdx
+++ b/src/pages/quickstarts/with-tailwindcss.mdx
@@ -24,18 +24,18 @@ pnpm create plasmo --with-tailwindcss
 
 ## Manual Installation
 
-If you already have a Plasmo extension project and would like to add TailwindCSS manually, this section is for you!
+If you already have a Plasmo extension project and would like to add TailwindCSS v3 manually, this section is for you!
 
 ### Add Dependencies
 
 ```bash
-pnpm i -D tailwindcss postcss autoprefixer
+pnpm i -D tailwindcss@3 postcss autoprefixer
 ```
 
 ### Generate your tailwind.config.js file
 
 ```bash
-npx tailwindcss init
+npx tailwindcss init -p
 ```
 
 ### Defining Your PostCSS Config


### PR DESCRIPTION
Since the release of tailwind v4, the `npx tailwindcss init` is no longer used, my PR was to change the docs to help user that choose Manual Installation to save debugging time and headache with simple edit in the documentation

Before:
![image](https://github.com/user-attachments/assets/dd56b214-2b99-4599-903f-66153586e7e7)


After:
![image](https://github.com/user-attachments/assets/0999ec25-47ed-4a8f-ab67-83568cbdf5ab)

[tailwind docs](https://github.com/tailwindlabs/tailwindcss/discussions/15820)