### PR TITLE
Specifying the correct locale naming convention for default_locale

### DIFF
--- a/src/pages/framework/locales.mdx
+++ b/src/pages/framework/locales.mdx
@@ -35,7 +35,7 @@ Create a `locales/en/messages.json` file with a JSON mapping between a unique `k
 }
 ```
 
-By default, Plasmo picks the first locale alphabetically available as default. However, you can specify a `default_locale` in your manifest like so:
+By default, Plasmo picks the first locale alphabetically available as default. However, you can specify a `default_locale` in your manifest following the locale directories naming convention (not chrome web store's loale naming convention) like so:
 
 ```json filename="package.json"
 {


### PR DESCRIPTION
This commit attempts to make clarifications on what locale code to use when specifying default_locale and is especially useful where the locales like en_US and en_GB or other similar locales are used. Chrome extension docs specify using en-US and en-GB respectively in these cases.